### PR TITLE
dts: apq8016: Fix downstream booting

### DIFF
--- a/dts/msm8916/apq8016-samsung-r05.dts
+++ b/dts/msm8916/apq8016-samsung-r05.dts
@@ -12,6 +12,8 @@
 		model = "Samsung Galaxy Tab E 9.6 WiFi (SM-T560NU)";
 		compatible = "samsung,gtelwifiue", "qcom,apq8016", "lk2nd,device";
 		lk2nd,match-bootloader = "T560*";
+		qcom,msm-id = <247 0>;
+		qcom,board-id = <0xF708FF01 1>;
 
 		samsung,muic-reset {
 			i2c-gpio-pins = <2 3>;


### PR DESCRIPTION
lk2nd used to boot the wrong dtb and downstream wouldnt work
tested on canadian firmware and it seems to be working for booting lineageos 19.1